### PR TITLE
Adding layer to display target position in "view on map"

### DIFF
--- a/nuc_layout.xml
+++ b/nuc_layout.xml
@@ -2008,4 +2008,5 @@
                 </itemgra>
  
             </layer>
+            <layer name="Found items" ref="Found items"/>
         </layout>


### PR DESCRIPTION
In the internal GUI, "view on map" displays a green circle with the name of the selected point.
For this to work, there must be a "Found items" layer in the layout.
